### PR TITLE
fix #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bluebird": "^2.9.30",
     "superagent": "^1.2.0",
-    "superagent-bluebird-promise": "^2.0.2"
+    "superagent-bluebird-promise": "^3.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^3.1.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-qiniu",
-  "version": "0.5.0",
+  "version": "1.4.0",
   "description": "A React Component to upload file to Qiniu ",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Yuan He <yuan@liulishuo.com>",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9.30",
+    "bluebird": "^3.0.0",
     "superagent": "^1.2.0",
     "superagent-bluebird-promise": "^3.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-qiniu",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A React Component to upload file to Qiniu ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fix [issuse#7](https://github.com/lenage/react-qiniu/issues/7)

---

As `superagent-bluebird-promise` has upgrade to `^3.0.2` to support `bluebird^3`, and the `cancelable` has been replaced by `cancel` in `bluebird^3`, you can find more detail here:

http://bluebirdjs.com/docs/api/cancellation.html
