### PR TITLE
Add feature : noautoload files to qiniu.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ var ReactQiniu = React.createClass({
         supportClick: React.PropTypes.bool,
         accept: React.PropTypes.string,
         multiple: React.PropTypes.bool,
+        autoUpload: React.PropTypes.bool,
         // Qiniu
         uploadUrl: React.PropTypes.string,
         prefix: React.PropTypes.string,
@@ -49,7 +50,8 @@ var ReactQiniu = React.createClass({
         return {
             supportClick: true,
             multiple: true,
-            uploadUrl: uploadUrl
+            uploadUrl: uploadUrl,
+            autoUpload: true
         };
     },
 
@@ -105,7 +107,14 @@ var ReactQiniu = React.createClass({
             }else{
                 files[i].preview = URL.createObjectURL(files[i]);
                 files[i].request = this.upload(files[i]);
-                files[i].uploadPromise = files[i].request.promise();
+                if (this.props.autoUpload)
+                {
+                    files[i].uploadPromise = files[i].request.promise();
+                }
+                else
+                {
+                    files[i].upload = files[i].request.promise.bind(files[i].request);
+                }
             }
         }
 


### PR DESCRIPTION
加了一个属性去判断是否要自动上传至七牛云

```
propTypes: {
        onDrop: React.PropTypes.func.isRequired,
        token: React.PropTypes.string.isRequired,
        // called before upload to set callback to files
        onUpload: React.PropTypes.func,
        size: React.PropTypes.number,
        style: React.PropTypes.object,
        supportClick: React.PropTypes.bool,
        accept: React.PropTypes.string,
        multiple: React.PropTypes.bool,
        autoUpload: React.PropTypes.bool,
        // Qiniu
        uploadUrl: React.PropTypes.string,
        prefix: React.PropTypes.string,
        //props to check File Size before upload.example:'2Mb','30k'...
        maxSize:React.PropTypes.string,
    }
```

onDrop方法里的改动
```
for (var i = 0; i < maxFiles; i++) {
            if( maxSizeLimit && files[i].size > maxSizeLimit){
               console.trace && console.trace(new Error('文件大小错误!'))
                this.props.onError && this.props.onError({
                   coed:1,
                   message:'上传的文件大小超出了限制:' + this.props.maxSize
               })
            }else{
                files[i].preview = URL.createObjectURL(files[i]);
                files[i].request = this.upload(files[i]);
                if (this.props.autoUpload)
                {
                    files[i].uploadPromise = files[i].request.promise();
                }
                else
                {
                    files[i].upload = files[i].request.promise.bind(files[i].request);
                }
            }
        }
```

[my demo](https://github.com/maybeShuo/react-qiniu-pr/blob/master/src/app/app.js)
