### PR TITLE
修复 react 更新带来的 PropTypes Warning 问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom')
 var request = require('superagent-bluebird-promise');
-
+var PropTypes = require('prop-types');
 var isFunction = function (fn) {
  var getType = {};
  return fn && getType.toString.call(fn) === '[object Function]';
@@ -13,19 +13,19 @@ var isFunction = function (fn) {
 var ReactQiniu = React.createClass({
     // based on https://github.com/paramaggarwal/react-dropzone
     propTypes: {
-        onDrop: React.PropTypes.func.isRequired,
-        token: React.PropTypes.string.isRequired,
+        onDrop: PropTypes.func.isRequired,
+        token: PropTypes.string.isRequired,
         // called before upload to set callback to files
-        onUpload: React.PropTypes.func,
-        size: React.PropTypes.number,
-        style: React.PropTypes.object,
-        supportClick: React.PropTypes.bool,
-        accept: React.PropTypes.string,
-        multiple: React.PropTypes.bool,
+        onUpload: PropTypes.func,
+        size: PropTypes.number,
+        style: PropTypes.object,
+        supportClick: PropTypes.bool,
+        accept: PropTypes.string,
+        multiple: PropTypes.bool,
         // Qiniu
-        uploadUrl: React.PropTypes.string,
-        uploadKey: React.PropTypes.string,
-        prefix: React.PropTypes.string
+        uploadUrl: PropTypes.string,
+        uploadKey: PropTypes.string,
+        prefix: PropTypes.string
     },
 
     getDefaultProps: function() {

--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ var ReactQiniu = React.createClass({
         multiple: PropTypes.bool,
         // Qiniu
         uploadUrl: PropTypes.string,
-        uploadKey: PropTypes.string,
-        prefix: PropTypes.string
+        prefix: PropTypes.string,
         //props to check File Size before upload.example:'2Mb','30k'...
         maxSize: PropTypes.string
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,87 @@
+{
+  "name": "react-qiniu",
+  "version": "1.5.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.5",
+      "resolved": "http://registry.npm.taobao.org/asap/download/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "http://registry.npm.taobao.org/core-js/download/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "http://registry.npm.taobao.org/encoding/download/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+    },
+    "fbjs": {
+      "version": "0.8.12",
+      "resolved": "http://registry.npm.taobao.org/fbjs/download/fbjs-0.8.12.tgz",
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+    },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "resolved": "http://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.18.tgz",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-stream/download/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "http://registry.npm.taobao.org/isomorphic-fetch/download/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+    },
+    "js-tokens": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.taobao.org/js-tokens/download/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.taobao.org/loose-envify/download/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+    },
+    "node-fetch": {
+      "version": "1.7.1",
+      "resolved": "http://registry.npm.taobao.org/node-fetch/download/node-fetch-1.7.1.tgz",
+      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "http://registry.npm.taobao.org/promise/download/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078="
+    },
+    "prop-types": {
+      "version": "15.5.10",
+      "resolved": "http://registry.npm.taobao.org/prop-types/download/prop-types-15.5.10.tgz",
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "ua-parser-js": {
+      "version": "0.7.13",
+      "resolved": "http://registry.npm.taobao.org/ua-parser-js/download/ua-parser-js-0.7.13.tgz",
+      "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/whatwg-fetch/download/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.0.0",
+    "prop-types": "^15.5.10",
     "superagent": "^1.2.0",
     "superagent-bluebird-promise": "^3.0.2"
   },


### PR DESCRIPTION
react v16.0 将会废除 React.PropTypes，这里将 index.js 中的 PropTypes 的引入改为 从库 prop-types 中引入。